### PR TITLE
Add section for learning algorithms in documentation. Start MCTS documentation

### DIFF
--- a/docs/learning-algorithms.md
+++ b/docs/learning-algorithms.md
@@ -1,0 +1,37 @@
+---
+title: "Learning Algorithms"
+nav_order: 2
+parent: "Smart Control Project Documentation"
+---
+
+# Learning Algorithms
+
+One of the goals of building a simulation environment like the one presented here is to use it to train learning algorithms to optimize control of that building. On that note, we provide implementation of a few learning algorithms implemented to explore this possibility.
+
+## Monte Carlo Tree Search
+
+MCTS is not technically an RL algorithm, but can be attempted and leveraged as a potential baseline performance metric.
+
+In the proposed setup, each node in the MCTS tree is identified by a given sequence of actions taken since the episode's start. Nodes in different depths of the tree are a fixed number of `expand_steps` apart, such that the MCTS agent can only decide on a new action every `expand_steps` number of steps.
+
+Implementing MCTS in this setup comes with a few challenges, which we highlight here:
+
+### Slow Rollouts and Paralellism
+
+Typically, a rollout in an MCTS consists of choosing some default policy (e.g. random moves in a game), and then playing the episode to completion. In this case, doing this is very slow, as running an environment simulation is time consuming. Because of this, we only perform rollouts for a smaller fixed number of steps `rollout_steps` after the corresponding node's timestamp.
+
+To address this problem, we also adapt the implementation to support paralellism using `multiprocessing`. This was favored instead of multithreading due to the GIL lock. Because we are not dealing with async operations, multithreading should not provide a performance benefit, as only one thread is allowed to execute code at a time. Multiprocessing however, allows multiple distinct python processes, which should then obtain a speedup.
+
+The design of `SbsimMonteCarloTreeSearchNode` and `SbSimMonteCarloTreeSearch` was adapted in order to support `multiprocessing`. For example, since the node objects can't be serialized and thus can't be passed into workers, methods such as `SbsimMonteCarloTreeSearchNode.run_rollout` are made static to allow workers to execute them independently.
+
+### Node Selection
+
+As described above, our implementation performs many concurrent rollouts. To choose which nodes to expand, the method `SbSimMonteCarloTreeSearch.get_nodes_for_expansion` is used. This method chooses the `@ param num_nodes` nodes to expand by finding adding a node if it is not fully expanded, and then recursively calling itself on the node's children, in order from the highest to lowest score. The constant `@ param c_param` should control the balance between exploration and exploitation.
+
+### Node Evaluation
+
+Node evaluation: to evaluate a node, we consider it's performance in comparison to the a baseline schedule policy. A node's score is given by the sum of the differences (when compared to the baseline policy return) of the rollout returns of all it's children. To keep things fair, this is then normalized by the sum of the number of hours elapsed until the rollout end for all children. In summary, this means that each node is scored by the *average rollout return improvement per hour for all it's children*.
+
+
+## Soft Actor Critic
+Implementation of this algorithm can be found in the `SAC_Demo.ipynb` notebook.

--- a/docs/learning-algorithms.md
+++ b/docs/learning-algorithms.md
@@ -8,30 +8,5 @@ parent: "Smart Control Project Documentation"
 
 One of the goals of building a simulation environment like the one presented here is to use it to train learning algorithms to optimize control of that building. On that note, we provide implementation of a few learning algorithms implemented to explore this possibility.
 
-## Monte Carlo Tree Search
-
-MCTS is not technically an RL algorithm, but can be attempted and leveraged as a potential baseline performance metric.
-
-In the proposed setup, each node in the MCTS tree is identified by a given sequence of actions taken since the episode's start. Nodes in different depths of the tree are a fixed number of `expand_steps` apart, such that the MCTS agent can only decide on a new action every `expand_steps` number of steps.
-
-Implementing MCTS in this setup comes with a few challenges, which we highlight here:
-
-### Slow Rollouts and Paralellism
-
-Typically, a rollout in an MCTS consists of choosing some default policy (e.g. random moves in a game), and then playing the episode to completion. In this case, doing this is very slow, as running an environment simulation is time consuming. Because of this, we only perform rollouts for a smaller fixed number of steps `rollout_steps` after the corresponding node's timestamp.
-
-To address this problem, we also adapt the implementation to support paralellism using `multiprocessing`. This was favored instead of multithreading due to the GIL lock. Because we are not dealing with async operations, multithreading should not provide a performance benefit, as only one thread is allowed to execute code at a time. Multiprocessing however, allows multiple distinct python processes, which should then obtain a speedup.
-
-The design of `SbsimMonteCarloTreeSearchNode` and `SbSimMonteCarloTreeSearch` was adapted in order to support `multiprocessing`. For example, since the node objects can't be serialized and thus can't be passed into workers, methods such as `SbsimMonteCarloTreeSearchNode.run_rollout` are made static to allow workers to execute them independently.
-
-### Node Selection
-
-As described above, our implementation performs many concurrent rollouts. To choose which nodes to expand, the method `SbSimMonteCarloTreeSearch.get_nodes_for_expansion` is used. This method chooses the `@ param num_nodes` nodes to expand by finding adding a node if it is not fully expanded, and then recursively calling itself on the node's children, in order from the highest to lowest score. The constant `@ param c_param` should control the balance between exploration and exploitation.
-
-### Node Evaluation
-
-Node evaluation: to evaluate a node, we consider it's performance in comparison to the a baseline schedule policy. A node's score is given by the sum of the differences (when compared to the baseline policy return) of the rollout returns of all it's children. To keep things fair, this is then normalized by the sum of the number of hours elapsed until the rollout end for all children. In summary, this means that each node is scored by the *average rollout return improvement per hour for all it's children*.
-
-
-## Soft Actor Critic
-Implementation of this algorithm can be found in the `SAC_Demo.ipynb` notebook.
+- [Monte Carlo Tree Search](docs/mcts.md)
+- [Soft Actor Critic](docs/sac.md)

--- a/docs/mcts.md
+++ b/docs/mcts.md
@@ -6,11 +6,11 @@ In the proposed setup, each node in the MCTS tree is identified by a given seque
 
 Implementing MCTS in this setup comes with a few challenges, which we highlight here:
 
-## Slow Rollouts and Paralellism
+## Slow Rollouts and Parallelism
 
 Typically, a rollout in an MCTS consists of choosing some default policy (e.g. random moves in a game), and then playing the episode to completion. In this case, doing this is very slow, as running an environment simulation is time consuming. Because of this, we only perform rollouts for a smaller fixed number of steps `rollout_steps` after the corresponding node's timestamp.
 
-To address this problem, we also adapt the implementation to support paralellism using `multiprocessing`. This was favored instead of multithreading due to the GIL lock. Because we are not dealing with async operations, multithreading should not provide a performance benefit, as only one thread is allowed to execute code at a time. Multiprocessing however, allows multiple distinct python processes, which should then obtain a speedup.
+To address this problem, we also adapt the implementation to support parallelism using `multiprocessing`. This was favored instead of multithreading due to the GIL lock. Because we are not dealing with async operations, multithreading should not provide a performance benefit, as only one thread is allowed to execute code at a time. Multiprocessing however, allows multiple distinct python processes, which should then obtain a speedup.
 
 The design of `SbsimMonteCarloTreeSearchNode` and `SbSimMonteCarloTreeSearch` was adapted in order to support `multiprocessing`. For example, since the node objects can't be serialized and thus can't be passed into workers, methods such as `SbsimMonteCarloTreeSearchNode.run_rollout` are made static to allow workers to execute them independently.
 
@@ -20,4 +20,4 @@ As described above, our implementation performs many concurrent rollouts. To cho
 
 ## Node Evaluation
 
-Node evaluation: to evaluate a node, we consider it's performance in comparison to the a baseline schedule policy. A node's score is given by the sum of the differences (when compared to the baseline policy return) of the rollout returns of all it's children. To keep things fair, this is then normalized by the sum of the number of hours elapsed until the rollout end for all children. In summary, this means that each node is scored by the *average rollout return improvement per hour for all it's children*.
+Node evaluation: to evaluate a node, we consider its performance in comparison to the a baseline schedule policy. A node's score is given by the sum of the differences (when compared to the baseline policy return) of the rollout returns of all its children. To keep things fair, this is then normalized by the sum of the number of hours elapsed until the rollout end for all children. In summary, this means that each node is scored by the *average rollout return improvement per hour for all it's children*.

--- a/docs/mcts.md
+++ b/docs/mcts.md
@@ -1,0 +1,23 @@
+# Monte Carlo Tree Search
+
+MCTS is not technically an RL algorithm, but can be attempted and leveraged as a potential baseline performance metric.
+
+In the proposed setup, each node in the MCTS tree is identified by a given sequence of actions taken since the episode's start. Nodes in different depths of the tree are a fixed number of `expand_steps` apart, such that the MCTS agent can only decide on a new action every `expand_steps` number of steps.
+
+Implementing MCTS in this setup comes with a few challenges, which we highlight here:
+
+## Slow Rollouts and Paralellism
+
+Typically, a rollout in an MCTS consists of choosing some default policy (e.g. random moves in a game), and then playing the episode to completion. In this case, doing this is very slow, as running an environment simulation is time consuming. Because of this, we only perform rollouts for a smaller fixed number of steps `rollout_steps` after the corresponding node's timestamp.
+
+To address this problem, we also adapt the implementation to support paralellism using `multiprocessing`. This was favored instead of multithreading due to the GIL lock. Because we are not dealing with async operations, multithreading should not provide a performance benefit, as only one thread is allowed to execute code at a time. Multiprocessing however, allows multiple distinct python processes, which should then obtain a speedup.
+
+The design of `SbsimMonteCarloTreeSearchNode` and `SbSimMonteCarloTreeSearch` was adapted in order to support `multiprocessing`. For example, since the node objects can't be serialized and thus can't be passed into workers, methods such as `SbsimMonteCarloTreeSearchNode.run_rollout` are made static to allow workers to execute them independently.
+
+## Node Selection
+
+As described above, our implementation performs many concurrent rollouts. To choose which nodes to expand, the method `SbSimMonteCarloTreeSearch.get_nodes_for_expansion` is used. This method chooses the `@ param num_nodes` nodes to expand by finding adding a node if it is not fully expanded, and then recursively calling itself on the node's children, in order from the highest to lowest score. The constant `@ param c_param` should control the balance between exploration and exploitation.
+
+## Node Evaluation
+
+Node evaluation: to evaluate a node, we consider it's performance in comparison to the a baseline schedule policy. A node's score is given by the sum of the differences (when compared to the baseline policy return) of the rollout returns of all it's children. To keep things fair, this is then normalized by the sum of the number of hours elapsed until the rollout end for all children. In summary, this means that each node is scored by the *average rollout return improvement per hour for all it's children*.

--- a/docs/sac.md
+++ b/docs/sac.md
@@ -1,0 +1,2 @@
+# Soft Actor Critic
+Implementation of this algorithm can be found in the `SAC_Demo.ipynb` notebook.

--- a/index.md
+++ b/index.md
@@ -19,6 +19,7 @@ The **Smart Control** project is a reinforcement learning (RL) environment desig
 - [Environment Module](docs/environment.md)
 - [Simulation Components](docs/simulation-components.md)
 - [Reward Functions](docs/reward-functions.md)
+- [Learning Algorithms](docs/learning-algorithms.md)
 - [Configuration](docs/configuration.md)
 - [System Interaction and Architecture](docs/system-architecture.md)
 - [Contributing to the Project](docs/contributing.md)


### PR DESCRIPTION
- Added a `Learning Algorithms` section to the documentation, for us to document different learning algorithms that were attempted with the environment.
- Added initial documentation for MCTS implementation.