### PR TITLE
Add necessary changes for local development setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,3 @@ gem "jekyll", "~> 4.3.4" # installed by `gem jekyll`
 # gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
 
 gem "just-the-docs", "0.10.0" # pinned to the current release
-# gem "just-the-docs"        # always download the latest release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,158 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    bigdecimal (3.1.9)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.1)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-aarch64-linux-musl)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86-linux-gnu)
+    ffi (1.17.1-x86-linux-musl)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.30.2)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-aarch64-linux)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-x86-linux)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.3.4)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    just-the-docs (0.10.0)
+      jekyll (>= 3.8.5)
+      jekyll-include-cache
+      jekyll-seo-tag (>= 2.0)
+      rake (>= 12.3.1)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.1)
+    rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.1)
+    rouge (4.5.1)
+    safe_yaml (1.0.5)
+    sass-embedded (1.86.0)
+      google-protobuf (~> 4.30)
+      rake (>= 13)
+    sass-embedded (1.86.0-aarch64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-aarch64-linux-musl)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-arm-linux-androideabi)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-arm64-darwin)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-riscv64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-riscv64-linux-musl)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-x86_64-darwin)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-x86_64-linux-android)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-x86_64-linux-musl)
+      google-protobuf (~> 4.30)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-android
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3.4)
+  just-the-docs (= 0.10.0)
+
+BUNDLED WITH
+   2.6.6

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,6 @@
 remote_theme: just-the-docs/just-the-docs
+theme: just-the-docs
+layout: "default"
 title: SBSIM Docs
 description: A community-maintained SBSIM Documentation
 logo: "logo.png"

--- a/docs/additional-resources.md
+++ b/docs/additional-resources.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Additional Resources"
 nav_order: 11
 parent: "Smart Control Project Documentation"

--- a/docs/base-reward-function.md
+++ b/docs/base-reward-function.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "BaseSetpointEnergyCarbonRewardFunction"
 nav_order: 1
 parent: "Reward Functions"

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Best Practices"
 nav_order: 10
 parent: "Smart Control Project Documentation"

--- a/docs/building-simulation.md
+++ b/docs/building-simulation.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Building Simulation"
 nav_order: 1
 parent: "Simulation Components"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Configuration"
 nav_order: 6
 parent: "Smart Control Project Documentation"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Contributing to the Project"
 nav_order: 9
 parent: "Smart Control Project Documentation"

--- a/docs/ddpg.md
+++ b/docs/ddpg.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Deep Deterministic Policy Gradient"
 nav_order: 3
 parent: "Learning Algorithms"

--- a/docs/electricity-energy-cost.md
+++ b/docs/electricity-energy-cost.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "ElectricityEnergyCost"
 nav_order: 4
 parent: "Reward Functions"

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Environment Module"
 nav_order: 2
 parent: "Smart Control Project Documentation"

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Glossary"
 nav_order: 12
 parent: "Smart Control Project Documentation"

--- a/docs/hvac-systems.md
+++ b/docs/hvac-systems.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "HVAC Systems"
 nav_order: 2
 parent: "Simulation Components"

--- a/docs/learning-algorithms.md
+++ b/docs/learning-algorithms.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Learning Algorithms"
 nav_order: 5
 parent: "Smart Control Project Documentation"

--- a/docs/mcts.md
+++ b/docs/mcts.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Monte Carlo Tree Search"
 nav_order: 1
 parent: "Learning Algorithms"

--- a/docs/metrics-interpretation.md
+++ b/docs/metrics-interpretation.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Metrics Interpretation"
 nav_order: 8
 parent: "Smart Control Project Documentation"

--- a/docs/natural-gas-energy-cost.md
+++ b/docs/natural-gas-energy-cost.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "NaturalGasEnergyCost"
 nav_order: 5
 parent: "Reward Functions"

--- a/docs/occupancy-models.md
+++ b/docs/occupancy-models.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Occupancy Models"
 nav_order: 4
 parent: "Simulation Components"

--- a/docs/regret-reward-function.md
+++ b/docs/regret-reward-function.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "SetpointEnergyCarbonRegretFunction"
 nav_order: 3
 parent: "Reward Functions"

--- a/docs/reward-functions.md
+++ b/docs/reward-functions.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Reward Functions"
 nav_order: 4
 parent: "Smart Control Project Documentation"

--- a/docs/sac.md
+++ b/docs/sac.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Soft Actor Critic"
 nav_order: 2
 parent: "Learning Algorithms"

--- a/docs/setpoint-reward-function.md
+++ b/docs/setpoint-reward-function.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "SetpointEnergyCarbonRewardFunction"
 nav_order: 2
 parent: "Reward Functions"

--- a/docs/simulation-components.md
+++ b/docs/simulation-components.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Simulation Components"
 nav_order: 3
 parent: "Smart Control Project Documentation"

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "System Interaction and Architecture"
 nav_order: 7
 parent: "Smart Control Project Documentation"

--- a/docs/td3.md
+++ b/docs/td3.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Twin Delayed Deep Deterministic Policy Gradient"
 nav_order: 4
 parent: "Learning Algorithms"

--- a/docs/weather-controllers.md
+++ b/docs/weather-controllers.md
@@ -1,4 +1,5 @@
 ---
+layout: "default"
 title: "Weather Controllers"
 nav_order: 3
 parent: "Simulation Components"

--- a/index.md
+++ b/index.md
@@ -1,4 +1,6 @@
 ---
+layout: default # need to add this
+layout: "default"
 title: "Smart Control Project Documentation"
 nav_order: 1
 has_children: true


### PR DESCRIPTION
Addition of the `layout` attribute to various documentation files and the update to the `Gemfile` to pin the `jekyll` version.

Documentation theme and layout configuration:

* [`_config.yml`]: Added `theme` and `layout` attributes to configure the default theme and layout for the documentation site.
* Various documentation files: Added `layout: "default"` to set the default layout for each documentation file, ensuring a consistent look and feel across the site.